### PR TITLE
Bump actions to Node 24 versions

### DIFF
--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -12,7 +12,7 @@ jobs:
       runs-on: ubuntu-latest
       steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Package
         run: |
@@ -22,7 +22,7 @@ jobs:
          tar czf audacity-manual-${{ github.event.inputs.version }}.tar.gz help
 
       - name: Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
             body: 'Audacity manual for version ${{ github.event.inputs.version }}'
             tag_name: v${{ github.event.inputs.version }}

--- a/.github/workflows/update_manual.yml
+++ b/.github/workflows/update_manual.yml
@@ -12,7 +12,7 @@ jobs:
       runs-on: ubuntu-latest
       steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Donwload
         run: |


### PR DESCRIPTION
GitHub removes the legacy Node 12/16/20 runtimes from Actions runners on 2026-09-16
